### PR TITLE
コンテンツの横幅をウィンドウサイズに合わせる

### DIFF
--- a/fxController.fxml
+++ b/fxController.fxml
@@ -4,22 +4,18 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.VBox?>
 
-
-<ScrollPane prefHeight="1000.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="fxController">
+<ScrollPane fitToWidth="true" prefHeight="1000.0" prefWidth="1000.0" style="-fx-background: DAE6F3;" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="fxController">
    <content>
-      <FlowPane fx:id="flow" hgap="4.0" prefHeight="1000.0" prefWidth="1000.0" prefWrapLength="680.0" style="-fx-background-color: DAE6F3;" vgap="4.0">
+      <VBox spacing="5.0">
          <children>
-            <Pane fx:id="upperPane" prefHeight="28.0" prefWidth="1000.0">
-               <children>
-                <Button fx:id="backButton" mnemonicParsing="false" onAction="#onClick" prefHeight="29.0" prefWidth="96.0" text="BACK" />
-               </children>
-            </Pane>
+          <Button fx:id="backButton" mnemonicParsing="false" onAction="#onClick" prefWidth="100.0" text="BACK" />
+            <FlowPane fx:id="flow" hgap="4.0" prefWrapLength="1000.0" style="-fx-background-color: DAE6F3;" vgap="4.0" />
          </children>
          <padding>
-            <Insets bottom="5.0" top="5.0" />
+            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
          </padding>
-      </FlowPane>
+      </VBox>
    </content>
 </ScrollPane>


### PR DESCRIPTION
現状、ウィンドウのサイズを変えても中身は付いてきません。
今、FXMLの構造は次のようになっています。

```
ScrollPane
┗ FlowPane
  ┣ Pane
  ┃ ┗ Button ("Back" ボタン)
  ┗ (ここにファイル用のボタンが入る)
```

これを、次のように変えます。
```
ScrollPane
┗ VBox
  ┣ Button ("Back" ボタン)
  ┗ FlowPane
    ┗ (ここにファイル用のボタンが入る)
```

VBoxを使うことで、Paneを大きくして無理やり他のボタンを追い出す必要がなくなります。
そして、VBoxをScrollPaneにフィット(ScrollPaneの`FitToWidth`をセットする)ことで、ウィンドウのリサイズにも対応できるようになります。